### PR TITLE
Add indicate when in value changing mode

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -2827,6 +2827,7 @@ template<typename T> void paramAction(uint8_t action, T& value, const __FlashStr
         lcd.print(menuid); lcd.print(' ');
         lcd.print(label); lcd_blanks(); lcd_blanks();
         lcd.setCursor(0, 1); // value on next line
+        if (menumode == 2) lcd.print('>');
       } else { // UPDATE (not in menu)
         lcd.setCursor(0, 1); lcd.print(label); lcd.print(F(": "));
       }


### PR DESCRIPTION
Display '>' in front of the value when we are changing the value. This
make it clear that we are changing the value or changing the menu item.