### PR TITLE
Improve CAT support

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -6,11 +6,11 @@
 
 #define VERSION   "1.02k"
 
-#define QCX             1   // When not using a uSDX: QCX specific features (QCX, QCX-SSB, QCX-DSP with alignment-feature)  (disable this to safe memory)
+//#define QCX             1   // When not using a uSDX: QCX specific features (QCX, QCX-SSB, QCX-DSP with alignment-feature)  (disable this to safe memory)
 
 #define DEBUG           1   // Hardware diagnostics (disable this to safe memory)
 #define KEYER           1   // CW keyer
-//#define CAT           1   // CAT-interface
+#define CAT           1   // CAT-interface
 #define F_XTAL 27005000     // 27MHz SI5351 crystal
 //#define F_XTAL 25004000   // 25MHz SI5351 crystal  (enable for uSDX-Barb or using a si5351 break-out board)
 //#define SWAP_ROTARY   1   // Swap rotary direction (enable for uSDX-Barb)
@@ -3031,9 +3031,9 @@ void Command_GETFreqA(const char* parameter)
   {
     // Set
     freq=(uint32_t)atol(parameter);
-  change=true;
-  //display_vfo(freq);
-}
+    change=true;
+    //display_vfo(freq);
+  }
 
   // Read & Answer
   Serial.print("FA");
@@ -3115,7 +3115,7 @@ void Command_MD(const char* parameter)
 {
 /*
   switch(*parameter)
-{
+  {
     case '1': mode = LSB;
     case '2': mode = USB;
     case '3': mode = CW;
@@ -3135,7 +3135,7 @@ void Command_MD(const char* parameter)
     case CW:  Catbuffer[2] = '3';
     case FM:  Catbuffer[2] = '4';
     case AM:  Catbuffer[2] = '5';
-}
+  }
 */
   Catbuffer[2] = '1' + mode;
 

--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -6,11 +6,11 @@
 
 #define VERSION   "1.02k"
 
-//#define QCX             1   // When not using a uSDX: QCX specific features (QCX, QCX-SSB, QCX-DSP with alignment-feature)  (disable this to safe memory)
+#define QCX             1   // When not using a uSDX: QCX specific features (QCX, QCX-SSB, QCX-DSP with alignment-feature)  (disable this to safe memory)
 
 #define DEBUG           1   // Hardware diagnostics (disable this to safe memory)
 #define KEYER           1   // CW keyer
-#define CAT           1   // CAT-interface
+//#define CAT           1   // CAT-interface
 #define F_XTAL 27005000     // 27MHz SI5351 crystal
 //#define F_XTAL 25004000   // 25MHz SI5351 crystal  (enable for uSDX-Barb or using a si5351 break-out board)
 //#define SWAP_ROTARY   1   // Swap rotary direction (enable for uSDX-Barb)

--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -3524,24 +3524,6 @@ void print_char(uint8_t in){  // Print char in second line of display and scroll
   cw_event = true;
 }
 
-static char cat[20];  // temporary here
-static uint8_t nc = 0;
-static uint16_t cat_cmd = 0;
-
-void parse_cat(uint8_t in){   // TS480 CAT protocol:  https://www.kenwood.com/i/products/info/amateur/ts_480/pdf/ts_480_pc.pdf
-  if(nc == 0) cat_cmd = in << 8;
-  if(nc == 1) cat_cmd += in;
-  if(in == ';'){  // end of cat command -> parse and process
-
-    switch(cat_cmd){
-      case 'I'<<8|'F': Serial.write("IF00010138000     +00000000002000000 ;"); lcd.setCursor(0, 0); lcd.print("IF"); break;
-    }
-    nc = 0;       // reset
-  } else {
-    if(nc < (sizeof(cat) - 1)) cat[nc++] = in; // buffer and count-up
-  }
-}
-
 void loop()
 {
 #ifdef CAT


### PR DESCRIPTION
1. Add more comments for the commands.
2. Improve the logic for set/read for all commands based on spec.
3. Change mode definition to align with CAT spec
4. reduce the size of implementation by 250 bytes