### PR TITLE
Mark ssb and dsp cap const when non-QCX

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -2457,8 +2457,14 @@ int analogSafeRead(uint8_t pin)
 }
 
 enum dsp_cap_t { ANALOG, DSP, SDR };
+#ifdef QCX
 uint8_t dsp_cap = 0;
 uint8_t ssb_cap = 0;
+#else
+ // force SSB and SDR capability
+const uint8_t ssb_cap = 1;
+const uint8_t dsp_cap = 2;
+#endif
 
 uint16_t analogSampleMic()
 {
@@ -3250,8 +3256,6 @@ void setup()
   //ssb_cap = 1; dsp_cap = 0;  // force SSB and standard QCX-RX capability
   //ssb_cap = 1; dsp_cap = 1;  // force SSB and DSP capability
   //ssb_cap = 1; dsp_cap = 2;  // force SSB and SDR capability
-#else
-  ssb_cap = 1; dsp_cap = 2;  // force SSB and SDR capability
 #endif  //QCX
 
   show_banner();


### PR DESCRIPTION
This tells compiler to optimized out all QCX related code. This saves ROM & RAM.

Before for non-QCX:
Sketch uses 27422 bytes (85%) of program storage space. Maximum is 32256 bytes.
Global variables use 1291 bytes (63%) of dynamic memory, leaving 757 bytes for local variables. Maximum is 2048 bytes.

After for non-QCX:
Sketch uses 26206 bytes (81%) of program storage space. Maximum is 32256 bytes.
Global variables use 1227 bytes (59%) of dynamic memory, leaving 821 bytes for local variables. Maximum is 2048 bytes.
