### PR TITLE
Save more memory for menu subsystem

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -2806,7 +2806,7 @@ void actionCommon(uint8_t action, uint8_t *ptr, uint8_t size) {
   }
 }
 
-template<typename T> void paramAction(uint8_t action, T& value, uint8_t menuid, const __FlashStringHelper* label, const char* enumArray[], int32_t _min, int32_t _max, bool continuous){
+template<typename T> void paramAction(uint8_t action, volatile T& value, uint8_t menuid, const __FlashStringHelper* label, const char* enumArray[], int32_t _min, int32_t _max, bool continuous){
   switch(action){
     case UPDATE:
     case UPDATE_MENU:
@@ -2831,6 +2831,7 @@ template<typename T> void paramAction(uint8_t action, T& value, uint8_t menuid, 
         break;
   }
 }
+
 uint32_t save_event_time = 0;
 uint32_t sec_event_time = 0;
 


### PR DESCRIPTION
Assume all volatile for menu controlled variables, which saves 602bytes.

Before:
Sketch uses 27804 bytes (86%) of program storage space. Maximum is 32256 bytes.
Global variables use 1291 bytes (63%) of dynamic memory, leaving 757 bytes for local variables. Maximum is 2048 bytes.

After:
Sketch uses 27202 bytes (84%) of program storage space. Maximum is 32256 bytes.
Global variables use 1291 bytes (63%) of dynamic memory, leaving 757 bytes for local variables. Maximum is 2048 bytes.