### PR TITLE
Fix for disappearing tuning cursor when RX/TX mode switches.

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -3198,6 +3198,7 @@ void switch_rxtx(uint8_t tx_enable){
   }
   OCR2A = (((float)F_CPU / (float)64) / (float)((tx_enable) ? F_SAMP_TX : F_SAMP_RX) + 0.5) - 1;
   TIMSK2 |= (1 << OCIE2A);  // enable timer compare interrupt TIMER2_COMPA_vect
+  stepsize_showcursor();
 }
 
 uint8_t rx_ph_q = 90;


### PR DESCRIPTION
The cursor which indicates tuning "step size" vanishes when mode changes RX->TX or TX->RX. This is because the LCD update which changes T->R or R->T leaves the cursor "off screen" to the right of the new R or T. Adding a call to stepsize_showcursor at the end of switch_rxtx fixes the problem.