### PR TITLE
using non-latching relays with DL2MAN's LPF V3

### DIFF
--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -1733,14 +1733,15 @@ static uint8_t prev_lpf_io = 0xff; // inits and resets all latches
 inline void set_lpf(uint8_t f){
 #ifdef LPF_SWITCHING_DL2MAN_USDX_REV3
   uint8_t lpf_io = (f > 26) ? IO1_3 : (f > 20) ? IO1_4 : (f > 17) ? IO1_2 : (f > 12) ? IO1_5 : (f > 8) ? IO1_1 : (f > 5) ? IO1_6 : (f > 4) ? IO1_0 : /*(f <= 4)*/ IO1_7; // cut-off freq in MHz to IO port of LPF relay
+#ifndef LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
+  if(prev_lpf_io != lpf_io){ ioext.write(1U << lpf_io); };  // set relay
+#else
   if(prev_lpf_io != lpf_io){ set_latch(prev_lpf_io, IO0_0, false); set_latch(lpf_io, IO0_0); prev_lpf_io = lpf_io; };  // set relay
+#endif //LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
 #else //LPF_SWITCHING_DL2MAN_USDX_REV2 LPF_SWITCHING_DL2MAN_USDX_REV2_BETA
   uint8_t lpf_io = (f > 12) ? IO0_3 : (f > 8) ? IO0_5 : (f > 5) ? IO0_7 : (f > 4) ? IO1_1 : /*(f <= 4)*/ IO1_3; // cut-off freq in MHz to IO port of LPF relay
-#ifndef LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
   if(prev_lpf_io != lpf_io){ set_latch(prev_lpf_io, IO0_1, false); set_latch(lpf_io, IO0_1); prev_lpf_io = lpf_io; };  // set relay
-#else
-  if(prev_lpf_io != lpf_io){ iioext.write(1U << lpf_io); prev_lpf_io = lpf_io; };  // set relay
-#endif //LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
+
 #endif
 }
 #endif  //LPF_SWITCHING_DL2MAN_USDX_REV3 LPF_SWITCHING_DL2MAN_USDX_REV2 REV2_BETA

--- a/QCX-SSB.ino
+++ b/QCX-SSB.ino
@@ -17,6 +17,7 @@
 //#define QCX            1   // Supports older (non-SDR) QCX HW modifications (QCX, QCX-SSB, QCX-DSP with I/Q alignment-feature)
 //#define OLED           1   // OLED display, connect SDA (PD2), SCL (PD3)
 #define LPF_SWITCHING_DL2MAN_USDX_REV3         1   // Enable 8-band filter bank switching: latching relays wired to a TCA/PCA9555 GPIO extender on the PC4/PC5 I2C bus; relays are using IO0.0 as common (ground), IO1.0..7 used by the individual latches K0-7 switching respectively LPFs for 10m, 15m, 17m, 20m, 30m, 40m, 60m, 80m
+//#define LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS    1 // Enable this if you are using non-latching version of the relays, the radio will draw extra 15mA current but will work ity any relay (by OH2UDS/TA7W Baris)
 //#define LPF_SWITCHING_DL2MAN_USDX_REV2       1   // Enable 5-band filter bank switching: latching relays wired to a TCA/PCA9555 GPIO extender on the PC4/PC5 I2C bus; relays are using IO0.1 as common (ground), IO0.3, IO0.5, IO0.7, IO1.1, IO1.3 used by the individual latches K1-5 switching respectively LPFs for 20m, 30m, 40m, 60m, 80m
 //#define LPF_SWITCHING_DL2MAN_USDX_REV2_BETA  1   // Enable 5-band filter bank switching: latching relays wired to a PCA9539PW   GPIO extender on the PC4/PC5 I2C bus; relays are using IO0.1 as common (ground), IO0.3, IO0.5, IO0.7, IO1.1, IO1.3 used by the individual latches K1-5 switching respectively LPFs for 20m, 30m, 40m, 60m, 80m
 //#define LPF_SWITCHING_DL2MAN_USDX_REV1       1   // Enable 3-band filter bank switching: latching relays wired to a PCA9536D    GPIO extender on the PC4/PC5 I2C bus; relays are using IO0 as common (ground), IO1-IO3 used by the individual latches K1-3 switching respectively LPFs for 20m, 40m, 80m
@@ -1735,7 +1736,11 @@ inline void set_lpf(uint8_t f){
   if(prev_lpf_io != lpf_io){ set_latch(prev_lpf_io, IO0_0, false); set_latch(lpf_io, IO0_0); prev_lpf_io = lpf_io; };  // set relay
 #else //LPF_SWITCHING_DL2MAN_USDX_REV2 LPF_SWITCHING_DL2MAN_USDX_REV2_BETA
   uint8_t lpf_io = (f > 12) ? IO0_3 : (f > 8) ? IO0_5 : (f > 5) ? IO0_7 : (f > 4) ? IO1_1 : /*(f <= 4)*/ IO1_3; // cut-off freq in MHz to IO port of LPF relay
+#ifndef LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
   if(prev_lpf_io != lpf_io){ set_latch(prev_lpf_io, IO0_1, false); set_latch(lpf_io, IO0_1); prev_lpf_io = lpf_io; };  // set relay
+#else
+  if(prev_lpf_io != lpf_io){ iioext.write(1U << lpf_io); prev_lpf_io = lpf_io; };  // set relay
+#endif //LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS
 #endif
 }
 #endif  //LPF_SWITCHING_DL2MAN_USDX_REV3 LPF_SWITCHING_DL2MAN_USDX_REV2 REV2_BETA


### PR DESCRIPTION
If you want to use cheap non-latching relays with DL2MSN's LowPassFilter design just enable the line 
//#define LPF_SWITCHING_DL2MAN_USDX_REV3_BUT_NONLATCHING_RELAYS 1
This will allow you to use non latching standard relays , but will cost you extra 15mA current draw...
